### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Bitcoin-powered AI tools marketplace accessible via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). Pay with Lightning Network micropayments — no signup or API keys required.
 
+<a href="https://glama.ai/mcp/servers/@cnghockey/sats4ai">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cnghockey/sats4ai/badge" alt="Sats4AI MCP server" />
+</a>
+
 ## MCP Endpoint
 
 ```


### PR DESCRIPTION
This PR adds a badge for the [Sats4AI](https://glama.ai/mcp/servers/@cnghockey/sats4ai) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cnghockey/sats4ai">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cnghockey/sats4ai/badge" alt="Sats4AI MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.