### PR TITLE
docs: add MCP Queen operational badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sats4ai-mcp
 
+[![MCP Queen operational grade](https://mcpqueen.com/badge/io.github.cnghockey/sats4ai.svg)](https://mcpqueen.com/s/io.github.cnghockey/sats4ai)
+
 <a href="https://glama.ai/mcp/servers/@cnghockey/sats4ai">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/@cnghockey/sats4ai/badge" />
 </a>


### PR DESCRIPTION
Adds the live MCP Queen operational-grade badge to the README, following the existing badge request in #4. The badge links to the current probe evidence and updates when that operational evidence changes. It describes observable MCP operations; it is not a security, privacy, data-quality, or compliance certification.